### PR TITLE
Fix SSR DOM access in accessibility utils

### DIFF
--- a/client/components/VoiceInterface.jsx
+++ b/client/components/VoiceInterface.jsx
@@ -157,17 +157,19 @@ export default function VoiceInterface({
       }
     });
     
-    const unsubscribeQuality = qualityManager.onQualityChange((newQuality, oldQuality, perfData) => {
-      setCurrentQuality(newQuality);
-      ariaAnnouncer.announce(`Performance quality adjusted to ${newQuality} level`);
-      
-      // Log quality change for debugging
-      console.log(`Quality adjusted from ${oldQuality} to ${newQuality}`, {
-        frameRate: perfData.avgFrameRate,
-        memoryUsage: perfData.avgMemoryUsage,
-        reason: qualityManager.getAdjustmentHistory().slice(-1)[0]?.reason
-      });
-    });
+    const unsubscribeQuality = qualityManager
+      ? qualityManager.onQualityChange((newQuality, oldQuality, perfData) => {
+          setCurrentQuality(newQuality);
+          ariaAnnouncer.announce(`Performance quality adjusted to ${newQuality} level`);
+
+          // Log quality change for debugging
+          console.log(`Quality adjusted from ${oldQuality} to ${newQuality}`, {
+            frameRate: perfData.avgFrameRate,
+            memoryUsage: perfData.avgMemoryUsage,
+            reason: qualityManager.getAdjustmentHistory().slice(-1)[0]?.reason
+          });
+        })
+      : () => {};
 
     // Register memory cleanup tasks for long conversation sessions
     const cleanupVisualization = memoryManager.registerCleanupTask(() => {
@@ -518,7 +520,9 @@ export default function VoiceInterface({
   const getVisualizerConfig = () => {
     const config = getLayoutConfiguration();
     const qualityManager = getQualityManager();
-    const qualitySettings = qualityManager.getQualitySettings(currentQuality);
+    const qualitySettings = qualityManager
+      ? qualityManager.getQualitySettings(currentQuality)
+      : {};
     
     return {
       size: config.visualizerSize,

--- a/client/utils/accessibility.js
+++ b/client/utils/accessibility.js
@@ -126,7 +126,8 @@ export class FocusManager {
   }
 
   // Move focus to next/previous focusable element
-  moveFocus(direction, container = document) {
+  moveFocus(direction, container = typeof document !== 'undefined' ? document : null) {
+    if (!container) return;
     const focusableElements = this.getFocusableElements(container);
     const currentIndex = focusableElements.indexOf(document.activeElement);
     
@@ -147,11 +148,14 @@ export class FocusManager {
 export class AriaAnnouncer {
   constructor() {
     this.liveRegions = new Map();
-    this.createLiveRegions();
+    if (typeof document !== 'undefined' && document.body) {
+      this.createLiveRegions();
+    }
   }
 
   // Create ARIA live regions for announcements
   createLiveRegions() {
+    if (typeof document === 'undefined' || !document.body) return;
     Object.values(ARIA_LIVE_TYPES).forEach(type => {
       if (type === ARIA_LIVE_TYPES.OFF) return;
       


### PR DESCRIPTION
## Summary
- avoid DOM usage when `document` isn't available
- gracefully handle missing quality manager

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68837fbb603c8329b41a3af0728878b1